### PR TITLE
fix icon & owner name

### DIFF
--- a/src/hooks/useDarkMode.tsx
+++ b/src/hooks/useDarkMode.tsx
@@ -18,6 +18,12 @@ const useDarkMode = () => {
     setMounted(true)
   }, [])
 
+  useEffect(() => {
+    if (currentTheme) {
+      setTheme(currentTheme)
+    }
+  }, [currentTheme])
+
   return {
     mounted,
     changeTheme,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -15,10 +15,11 @@ interface HomeProps {
 }
 
 const Home: NextPage<HomeProps> = ({ blogs = [] }) => {
+  const ownerName: string = process.env.NEXT_PUBLIC_OWNER_NAME as string
   const meta = {
-    title: process.env.NEXT_PUBLIC_OWNER_NAME as string,
+    title: ownerName,
     template: 'Personal Blog',
-    description: `I'm John Doe, a software engineer in one of the biggest tech industry in the world, I personally writing mostly about web development and tech careers.`,
+    description: `I'm ${ownerName}, a software engineer in one of the biggest tech industry in the world, I personally writing mostly about web development and tech careers.`,
     openGraph: {
       images: [
         {


### PR DESCRIPTION
At initial load, when theme is empty in local storage it show a wrong icon for the dark mode button

![image](https://user-images.githubusercontent.com/54741166/164038110-79876cb4-3198-4965-a4f7-c215002b0408.png)

And the name in hero section, I think is better if also follow the title

![image](https://user-images.githubusercontent.com/54741166/164038433-ac5eee58-4aef-4322-b225-cbc80f484dd5.png)
